### PR TITLE
Bugfix: get_n_deps throws error when package has 0 dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: SCTORvalidation
 Type: Package
 Title: Tools for assisting with package validation within the SCTO package
     validation projedct of the Statistics and Methodology platform
-Version: 0.4.3
+Version: 0.4.4
 Authors@R: 
     c(
     person(given = "Alan G.", family = "Haynes", role = "cre",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# SCTORvalidation 0.4.4
+
+Bug fix:
+
+* get_n_deps throwed an error when a package had 0 dependencies in "Depends" or "Imports"
+
 # SCTORvalidation 0.4.3
 
 `extract_elements_test` uses laxy regex to extract OS. It previously used greedy regex which caused issues when a package also loaded the Matrix package

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 Bug fix:
 
-* get_n_deps throwed an error when a package had 0 dependencies in "Depends" or "Imports"
+* get_n_deps threw an error when a package had 0 dependencies in "Depends" or "Imports"
 
 # SCTORvalidation 0.4.3
 

--- a/R/get_n_deps.R
+++ b/R/get_n_deps.R
@@ -31,6 +31,9 @@ get_n_deps <- function(package, fields = c("Depends", "Imports"), ...){
   if(length(package) > 1) stop("Only one package at a time...")
 
   dsc <- packageDescription(package, fields = fields, ...)
+
+  dsc <- dsc[!is.na(dsc)]
+  
   deps <- lapply(dsc, strsplit, split = ",") |>
     unlist() |>
     trimws()


### PR DESCRIPTION
A small bugfix for #10 